### PR TITLE
Upgrade LibreHardwareMonitorLib from 0.9.4 to 0.9.6

### DIFF
--- a/service/LibreHardwareService.csproj
+++ b/service/LibreHardwareService.csproj
@@ -21,10 +21,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
     <PackageReference Include="MessagePack" Version="3.1.3" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="System.Threading.AccessControl" Version="8.0.0" />
+    <PackageReference Include="System.Threading.AccessControl" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/service/src/core/SensorsManager.cs
+++ b/service/src/core/SensorsManager.cs
@@ -9,11 +9,11 @@
  */
 
 using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware.Storage;
 using System.Diagnostics;
 using System.Text;
 using MessagePack;
 using Microsoft.IO;
-using LibreHardwareMonitor.Hardware.Storage;
 using static LibreHardwareService.ConfigHelper;
 
 namespace LibreHardwareService {
@@ -223,8 +223,10 @@ namespace LibreHardwareService {
             using (MemoryStream stream = recyclableMemoryStreamManager.GetStream()) {
                 using (BinaryWriter writer = new BinaryWriter(stream)) {
                     foreach (IHardware h in computer.Hardware) {
-                        if (h.HardwareType.Equals(HardwareType.Storage)) {
-                            if (h is AtaStorage) {
+                        if (h.HardwareType.Equals(HardwareType.Storage) && h is StorageDevice storageDevice) {
+                            bool isNvme = storageDevice.Storage.IsNVMe;
+
+                            if (!isNvme) {
                                 List<DataSmartAttribute> attrList = new List<DataSmartAttribute>();
                                 HwStatusInfo hwStatus = new HwStatusInfo {
                                     Identifier = h.Identifier.ToString(),
@@ -232,38 +234,21 @@ namespace LibreHardwareService {
                                     HardwareType = h.HardwareType.ToString(),
                                     HwStatusType = HwStatusType.STORAGE_SMART_ATA,
                                 };
-                                AtaStorage storage = (AtaStorage)h;
-                                LibreHardwareMonitor.Interop.Kernel32.SMART_ATTRIBUTE[] attrs = storage.Smart.ReadSmartData();
-                                LibreHardwareMonitor.Interop.Kernel32.SMART_THRESHOLD[] thresholds =
-                                    storage.Smart.ReadSmartThresholds();
 
-                                foreach (LibreHardwareMonitor.Interop.Kernel32.SMART_ATTRIBUTE a in attrs) {
-                                    if (a.Id == 0x00) {
-                                        break;
-                                    }
+                                foreach (var sa in storageDevice.Attributes) {
+                                    if (sa.Id == 0x00) continue;
+                                    var raw = sa.Attribute?.Attribute;
 
-#pragma warning disable CS8600  // Converting null literal or possible null value to non-nullable type.
-                                    SmartAttribute attr = storage.SmartAttributes.FirstOrDefault(s => s.Id == a.Id);
-#pragma warning restore CS8600  // Converting null literal or possible null value to non-nullable type.
-                                    string attrName = "Unknown";
-                                    if (attr != null) {
-                                        attrName = attr.Name;
-                                    }
-
-                                    byte threshold = 0;
-                                    foreach (LibreHardwareMonitor.Interop.Kernel32.SMART_THRESHOLD t in thresholds) {
-                                        if (t.Id == a.Id) {
-                                            threshold = t.Threshold;
-                                        }
-                                    }
                                     attrList.Add(new DataSmartAttribute {
-                                        Id = a.Id,
-                                        Name = attrName,
-                                        Threshold = threshold,
-                                        Flags = a.Flags,
-                                        RawValue = new List<Byte>(a.RawValue),
-                                        CurrentValue = a.CurrentValue,
-                                        WorstValue = a.WorstValue,
+                                        Id = sa.Id,
+                                        Name = sa.Name ?? "Unknown",
+                                        Threshold = raw?.Threshold ?? sa.Threshold,
+                                        Flags = raw?.StatusFlags ?? 0,
+                                        RawValue = raw.HasValue && raw.Value.RawValue != null
+                                            ? new List<Byte>(raw.Value.RawValue.Take(6))
+                                            : new List<Byte>(BitConverter.GetBytes((ulong)sa.Value).Take(6)),
+                                        CurrentValue = raw?.CurrentValue ?? 0,
+                                        WorstValue = raw?.WorstValue ?? 0,
                                     });
                                 }
 
@@ -279,36 +264,73 @@ namespace LibreHardwareService {
                                 if (IsDebug) {
                                     Console.WriteLine(Utf8Json.JsonSerializer.PrettyPrint(hwStatusData));
                                 }
-                            } else if (h is NVMeGeneric) {
-                                NVMeGeneric n = (NVMeGeneric)h;
-                                NVMeHealthInfo nh = n.Smart.GetHealthInfo();
+                            } else {
+                                var smart = storageDevice.Storage?.Smart;
+                                if (smart == null) continue;
                                 HwStatusInfo hwStatus = new HwStatusInfo {
                                     Identifier = h.Identifier.ToString(),
                                     Name = h.Name,
                                     HardwareType = h.HardwareType.ToString(),
                                     HwStatusType = HwStatusType.STORAGE_SMART_NVME
                                 };
-                                DataNvmeSmart nvmeSmart =
-                                    new DataNvmeSmart {
-                                        AvailableSpare = nh.AvailableSpare,
-                                        AvailableSpareThreshold = nh.AvailableSpareThreshold,
-                                        ControllerBusyTime = nh.ControllerBusyTime,
-                                        CriticalCompositeTemperatureTime = nh.CriticalCompositeTemperatureTime,
-                                        CriticalWarning = (byte)nh.CriticalWarning,
-                                        DataUnitRead = nh.DataUnitRead,
-                                        DataUnitWritten = nh.DataUnitWritten,
-                                        ErrorInfoLogEntryCount = nh.ErrorInfoLogEntryCount,
-                                        HostReadCommands = nh.HostReadCommands,
-                                        HostWriteCommands = nh.HostWriteCommands,
-                                        MediaErrors = nh.MediaErrors,
-                                        PercentageUsed = nh.PercentageUsed,
-                                        PowerCycle = nh.PowerCycle,
-                                        PowerOnHours = nh.PowerOnHours,
-                                        Temperature = nh.Temperature,
-                                        TemperatureSensors = nh.TemperatureSensors,
-                                        UnsafeShutdowns = nh.UnsafeShutdowns,
-                                        WarningCompositeTemperatureTime = nh.WarningCompositeTemperatureTime
-                                    };
+
+                                short temp = (short)(smart.Temperature ?? 0);
+
+                                // Map NVMe attributes from unified SMART list
+                                byte availableSpare = 0, availableSpareThreshold = 0, percentageUsed = 0, criticalWarning = 0;
+                                ulong hostReadCommands = 0, hostWriteCommands = 0;
+                                ulong unsafeShutdowns = 0, mediaErrors = 0, errorInfoLogEntryCount = 0;
+                                ulong controllerBusyTime = 0;
+                                uint warningTempTime = (uint)(smart.TemperatureWarning ?? 0);
+                                uint criticalTempTime = (uint)(smart.TemperatureCritical ?? 0);
+
+                                foreach (var attr in storageDevice.Attributes) {
+                                    var name = attr.Name?.ToLowerInvariant() ?? "";
+                                    var raw = (ulong)attr.Value;
+                                    if (name.Contains("available spare") && !name.Contains("threshold"))
+                                        availableSpare = (byte)Math.Min(raw, 255);
+                                    else if (name.Contains("available spare") && name.Contains("threshold"))
+                                        availableSpareThreshold = (byte)Math.Min(raw, 255);
+                                    else if (name.Contains("percentage used"))
+                                        percentageUsed = (byte)Math.Min(raw, 255);
+                                    else if (name.Contains("critical warning"))
+                                        criticalWarning = (byte)raw;
+                                    else if (name.Contains("host read"))
+                                        hostReadCommands = raw;
+                                    else if (name.Contains("host write"))
+                                        hostWriteCommands = raw;
+                                    else if (name.Contains("unsafe shutdown"))
+                                        unsafeShutdowns = raw;
+                                    else if (name.Contains("media") && name.Contains("error"))
+                                        mediaErrors = raw;
+                                    else if (name.Contains("error") && name.Contains("log"))
+                                        errorInfoLogEntryCount = raw;
+                                    else if (name.Contains("controller busy"))
+                                        controllerBusyTime = raw;
+                                }
+
+                                DataNvmeSmart nvmeSmart = new DataNvmeSmart {
+                                    AvailableSpare = availableSpare,
+                                    AvailableSpareThreshold = availableSpareThreshold,
+                                    ControllerBusyTime = controllerBusyTime,
+                                    CriticalCompositeTemperatureTime = criticalTempTime,
+                                    CriticalWarning = criticalWarning,
+                                    DataUnitRead = smart.HostReads ?? 0,
+                                    DataUnitWritten = smart.HostWrites ?? 0,
+                                    ErrorInfoLogEntryCount = errorInfoLogEntryCount,
+                                    HostReadCommands = hostReadCommands,
+                                    HostWriteCommands = hostWriteCommands,
+                                    MediaErrors = mediaErrors,
+                                    PercentageUsed = percentageUsed,
+                                    PowerCycle = smart.PowerOnCount,
+                                    PowerOnHours = smart.DetectedPowerOnHours,
+                                    Temperature = temp,
+                                    TemperatureSensors = temp != 0
+                                        ? new short[] { temp }
+                                        : Array.Empty<short>(),
+                                    UnsafeShutdowns = unsafeShutdowns,
+                                    WarningCompositeTemperatureTime = warningTempTime
+                                };
                                 byte[] hwStatusInfo = Utf8Json.JsonSerializer.Serialize(hwStatus);
                                 byte[] hwStatusData = Utf8Json.JsonSerializer.Serialize(nvmeSmart);
                                 writer.Write(8 + hwStatusInfo.Length + 4 + hwStatusData.Length + 1);

--- a/showsensors/src/Program.cs
+++ b/showsensors/src/Program.cs
@@ -53,81 +53,18 @@ namespace ShowSensors {
             foreach (IHardware h in computer.Hardware) {
                 Console.WriteLine("Hardware: name='{0}'; type='{1}'; identifier='{2}';", h.Name, h.HardwareType, h.Identifier);
 
-                if (h.HardwareType.Equals(HardwareType.Storage)) {
-                    if (h is AtaStorage) {
-                        List<DataSmartAttribute> attrList = new List<DataSmartAttribute>();
-                        HwStatusInfo hwStatus = new HwStatusInfo {
-                            Identifier = h.Identifier.ToString(),
-                            Name = h.Name,
-                            HardwareType = h.HardwareType.ToString(),
-                            HwStatusType = HwStatusType.STORAGE_SMART_ATA,
-                        };
-                        AtaStorage storage = (AtaStorage)h;
-                        LibreHardwareMonitor.Interop.Kernel32.SMART_ATTRIBUTE[] attrs = storage.Smart.ReadSmartData();
-                        LibreHardwareMonitor.Interop.Kernel32.SMART_THRESHOLD[] thresholds = storage.Smart.ReadSmartThresholds();
-
-                        foreach (LibreHardwareMonitor.Interop.Kernel32.SMART_ATTRIBUTE a in attrs) {
-                            if (a.Id == 0x00) {
-                                break;
-                            }
-
-                            SmartAttribute? attr = storage.SmartAttributes.FirstOrDefault(s => s.Id == a.Id);
-                            string attrName = "Unknown";
-                            if (attr != null) {
-                                attrName = attr.Name;
-                            }
-
-                            byte threshold = 0;
-                            foreach (LibreHardwareMonitor.Interop.Kernel32.SMART_THRESHOLD t in thresholds) {
-                                if (t.Id == a.Id) {
-                                    threshold = t.Threshold;
-                                }
-                            }
-                            DataSmartAttribute d = new DataSmartAttribute {
-                                Id = a.Id,
-                                Name = attrName,
-                                Threshold = threshold,
-                                Flags = a.Flags,
-                                RawValue = new List<Byte>(a.RawValue),
-                                CurrentValue = a.CurrentValue,
-                                WorstValue = a.WorstValue,
-                            };
-                            Console.WriteLine(
-                                "\t\tsmart-attribute: [[name:'{0}'; id:'{1}'; rawValue:'{2}';\n\t\t\tcurrentValue:'{3}'; threshold:'{4}'; worst:'{5}'; prefail:'{6}'; advisory:'{7}';]]",
-                                d.Name, "0x" + Convert.ToString(d.Id, 16), BitConverter.ToString(a.RawValue), d.CurrentValue,
-                                d.Threshold, d.WorstValue, d.IsPreFail, d.IsAdvisory);
-                        }
-                    } else if (h is NVMeGeneric) {
-                        NVMeGeneric n = (NVMeGeneric)h;
-                        NVMeHealthInfo nh = n.Smart.GetHealthInfo();
-                        HwStatusInfo hwStatus = new HwStatusInfo {
-                            Identifier = h.Identifier.ToString(),
-                            Name = h.Name,
-                            HardwareType = h.HardwareType.ToString(),
-                            HwStatusType = HwStatusType.STORAGE_SMART_NVME
-                        };
-                        DataNvmeSmart nvmeSmart =
-                            new DataNvmeSmart {
-                                AvailableSpare = nh.AvailableSpare,
-                                AvailableSpareThreshold = nh.AvailableSpareThreshold,
-                                ControllerBusyTime = nh.ControllerBusyTime,
-                                CriticalCompositeTemperatureTime = nh.CriticalCompositeTemperatureTime,
-                                CriticalWarning = (byte)nh.CriticalWarning,
-                                DataUnitRead = nh.DataUnitRead,
-                                DataUnitWritten = nh.DataUnitWritten,
-                                ErrorInfoLogEntryCount = nh.ErrorInfoLogEntryCount,
-                                HostReadCommands = nh.HostReadCommands,
-                                HostWriteCommands = nh.HostWriteCommands,
-                                MediaErrors = nh.MediaErrors,
-                                PercentageUsed = nh.PercentageUsed,
-                                PowerCycle = nh.PowerCycle,
-                                PowerOnHours = nh.PowerOnHours,
-                                Temperature = nh.Temperature,
-                                TemperatureSensors = nh.TemperatureSensors,
-                                UnsafeShutdowns = nh.UnsafeShutdowns,
-                                WarningCompositeTemperatureTime = nh.WarningCompositeTemperatureTime
-                            };
-                        Console.WriteLine("\tsmart-attribute: {0}", nvmeSmart);
+                if (h.HardwareType.Equals(HardwareType.Storage) && h is StorageDevice storageDevice) {
+                    foreach (var sa in storageDevice.Attributes) {
+                        if (sa.Id == 0x00) continue;
+                        var raw = sa.Attribute?.Attribute;
+                        Console.WriteLine(
+                            "\t\tsmart-attribute: [[name:'{0}'; id:'0x{1:x2}'; rawValue:'{2}';\n\t\t\tcurrentValue:'{3}'; threshold:'{4}'; worst:'{5}';]]",
+                            sa.Name ?? "Unknown",
+                            sa.Id,
+                            raw.HasValue && raw.Value.RawValue != null ? BitConverter.ToString(raw.Value.RawValue) : sa.Value.ToString(),
+                            raw?.CurrentValue ?? 0,
+                            raw?.Threshold ?? sa.Threshold,
+                            raw?.WorstValue ?? 0);
                     }
                 }
 


### PR DESCRIPTION
## Summary

Upgrades LibreHardwareMonitorLib from 0.9.4 to 0.9.6 and migrates the storage SMART code to the new `StorageDevice` / DiskInfoToolkit API.

## Motivation

LHM 0.9.4 lacks sensor support for newer hardware. On AMD Zen 5 CPUs (e.g., Ryzen 9 9950X3D), only Load sensors are reported — no Temperature, Clock, Power, or Voltage. After upgrading to 0.9.6, all of these sensors are detected and reported correctly through shared memory.

## Changes

- **LibreHardwareMonitorLib** 0.9.4 → 0.9.6
- **System.Threading.AccessControl** 8.0.0 → 10.0.3 (required by LHM 0.9.6)
- **SensorsManager.cs** — migrated `updateHardwareStatus()`:
  - ATA SMART: replaced `AtaStorage` / `Kernel32.SMART_ATTRIBUTE` / `SMART_THRESHOLD` with `StorageDevice.Attributes` and `SmartAttributeStructure` fields
  - NVMe SMART: replaced `NVMeGeneric` / `NVMeHealthInfo` with `StorageDevice.Storage.Smart` (SmartInfo) for core health data, plus unified Attributes list for fields not directly exposed (available spare, percentage used, etc.)
  - Added null guard for `storageDevice.Storage?.Smart`
- **ShowSensors** — simplified SMART display to use unified `StorageDevice.Attributes` for both ATA and NVMe

## Wire Format Compatibility

The `DataSmartAttribute` and `DataNvmeSmart` model structs are **unchanged**, so the shared memory format remains backwards-compatible with existing consumers (e.g., the Rainmeter plugin).

## Known Limitations

- **NVMe temperature sensors array**: The old `NVMeHealthInfo.TemperatureSensors` provided a multi-sensor array. The new API exposes a single primary temperature via `SmartInfo.Temperature`, so the array is synthesized as a single-element array.
- **NVMe attribute extraction**: Some NVMe health fields (available spare, percentage used, controller busy time, etc.) are extracted from the unified Attributes list by matching attribute names. This is necessary because DiskInfoToolkit's `SmartInfo` doesn't directly expose all NVMe SMART log fields.
- **float precision for large counters**: `SmartAttribute.Value` is `float`, which may lose precision for very large NVMe counter values (e.g., host read/write commands exceeding ~16M). The core health data routed through `SmartInfo` (HostReads, HostWrites, PowerOnCount, etc.) uses proper integer types.
- **TemperatureWarning/TemperatureCritical semantics**: `SmartInfo.TemperatureWarning` and `SmartInfo.TemperatureCritical` are mapped to `DataNvmeSmart.WarningCompositeTemperatureTime` and `CriticalCompositeTemperatureTime` respectively. These may represent threshold temperatures rather than time-above-threshold durations — please verify if this mapping is semantically correct for your use case.

## Testing

- Built and installed on Windows 11 with AMD Ryzen 9 9950X3D + NVIDIA RTX 5090
- Service starts and runs correctly, CPU/GPU/RAM/Network/Storage sensors all reported via shared memory
- ShowSensors displays all detected hardware and SMART attributes
- Verified with rainmeter-lhws plugin — sensor data reads correctly